### PR TITLE
Make quake3 have a numplayers variable too

### DIFF
--- a/protocols/quake3.js
+++ b/protocols/quake3.js
@@ -6,14 +6,14 @@ module.exports = require('./quake2').extend({
 	},
 	finalizeState: function(state) {
 		state.name = this.stripColors(state.name);
-		state.raw.numplayers = state.players.length;
-		
 		for(var i in state.raw) {
 			state.raw[i] = this.stripColors(state.raw[i]);
 		}
 		for(var i = 0; i < state.players.length; i++) {
 			state.players[i].name = this.stripColors(state.players[i].name);
 		}
+		
+		state.raw.numplayers = state.players.length;
 	},
 	stripColors: function(str) {
 		return str.replace(/\^(X.{6}|.)/g,'');

--- a/protocols/quake3.js
+++ b/protocols/quake3.js
@@ -6,6 +6,8 @@ module.exports = require('./quake2').extend({
 	},
 	finalizeState: function(state) {
 		state.name = this.stripColors(state.name);
+		state.raw.numplayers = state.players.length;
+		
 		for(var i in state.raw) {
 			state.raw[i] = this.stripColors(state.raw[i]);
 		}


### PR DESCRIPTION
When you query a quake 3 server (like Wolfenstein Enemy Terroritory) it basically gets the player names, but it does not have a raw.numplayers variable. With this it's added :)