### PR TITLE
Teamspeak 3 - avoid ServerQuery clients

### DIFF
--- a/protocols/teamspeak3.js
+++ b/protocols/teamspeak3.js
@@ -25,7 +25,9 @@ module.exports = require('./core').extend({
 					for(var i = 0; i < data.length; i++) {
 						data[i].name = data[i].client_nickname;
 						delete data[i].client_nickname;
-						state.players.push(data[i]);
+						if(data[i].client_type == 0) {
+							state.players.push(data[i]);
+						}
 					}
 					c();
 				});


### PR DESCRIPTION
Says it all.

(From teamspeak 3 server query manual)
CLIENT_TYPE - Indicates whether the client is a ServerQuery client or not

1 equals server query client.