### PR TITLE
Timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ function(e,state) {
 * **type**: One of the game IDs listed in the game list below
 * **host**
 * **port**: (optional) Uses the protocol default if not set
+* **timeout**: (optional) The max timeout, in milliseconds, for both UDP & TCP requests (default: 1000)
 * **notes**: (optional) Passed through to output
 
 ### Return Value

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,12 @@ class Gamedig {
             query.udpSocket = udpSocket;
             query.type = options.type;
 
+            if ( options.timeout ){
+                query.options.tcpTimeout = options.timeout
+                query.options.udpTimeout = options.timeout
+                delete options.timeout
+            }
+
             if(!('port' in query.options) && ('port_query' in query.options)) {
                 if(Gamedig.isCommandLine) {
                     process.stderr.write(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gamedig",
-	"version": "0.2.30",
+	"version": "1.0.37",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Can now set a "timeout" option at query level (in milliseconds). Will be applied to both TCP & UDP requests.

Is useful for servers located far away where the default 1 second timeout is too low (in my case, Australian server can take up to 1.5 seconds to reply).

Example :

`GameDig.query({ type: 'XXX', host: 'xxx.xxx.xxx.xxx', port: 123, timeout: 1000})`