### PR TITLE
Max attempts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ function(e,state) {
 * **type**: One of the game IDs listed in the game list below
 * **host**
 * **port**: (optional) Uses the protocol default if not set
+* **maxAttempts**: (optional) How many times should the query be retried in case it fails
 * **notes**: (optional) Passed through to output
 
 ### Return Value

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,12 @@ class Gamedig {
             query.udpSocket = udpSocket;
             query.type = options.type;
 
+            if ( options.maxAttempts ){
+                query.maxAttempts = options.maxAttempts
+                query.maxAttempts = options.maxAttempts
+                delete options.maxAttempts
+            }
+
             if(!('port' in query.options) && ('port_query' in query.options)) {
                 if(Gamedig.isCommandLine) {
                     process.stderr.write(


### PR DESCRIPTION
Can now set a "maxAttempts" option to rule how many times a request should be retried until it finally fails.

Was part of the core implementation, just added the possibility to have this option set from the exposed query() method.

Example :

`GameDig.query({ type: 'XXX', host: 'xxx.xxx.xxx.xxx', port: 123, maxAttempts: 5})`