### PR TITLE
Handle JSON parsing inside try/catch loop to handle error in callback.

### DIFF
--- a/protocols/minecraft.js
+++ b/protocols/minecraft.js
@@ -71,12 +71,13 @@ class Minecraft extends require('./core') {
                 try {
                     json = JSON.parse(str);
                     delete json.favicon;
+
+                    state.raw = json;
+                    state.maxplayers = json.players.max;
                 } catch(e) {
                     return this.fatal('Invalid JSON');
                 }
 
-                state.raw = json;
-                state.maxplayers = json.players.max;
                 if(json.players.sample) {
                     for(const player of json.players.sample) {
                         state.players.push({


### PR DESCRIPTION
If you ping a Minecraft server at just the right time (during boot), it will return JSON that is not in the typical format returned. 
This should be handled in the callback (as an error variable is passed to it), but since parts of the JSON is parsed outside of the try/catch loop, it goes unhanded, and throws an error.
