### PR TITLE
Adjusted Terraria protocol to check the "status" property for string …

### DIFF
--- a/protocols/terraria.js
+++ b/protocols/terraria.js
@@ -11,7 +11,7 @@ class Terraria extends Core {
         });
 
         const json = JSON.parse(body);
-        if(json.status !== 200) throw new Error('Invalid status');
+        if(json.status !== '200') throw new Error('Invalid status');
 
         for (const one of json.players) {
             state.players.push({name:one.nickname,team:one.team});


### PR DESCRIPTION
…"200" rather than integer 200.

I am not sure if the TShock API changed this recently or what, but it returns a string in the current version (4.3.26 for Terraria 1.3.5.3), and comparing it to an integer was incorrectly causing an "Invalid status" error.