### PR TITLE
Add check for Password_b on Squad Servers to correct password field.

### DIFF
--- a/games.txt
+++ b/games.txt
@@ -231,7 +231,7 @@ stalker|S.T.A.L.K.E.R.|gamespy3|port=5445,port_query_offset=2
 stbc|Star Trek: Bridge Commander|gamespy1|port_query=22101
 stvef|Star Trek: Voyager - Elite Force|quake3|port_query=27960
 stvef2|Star Trek: Voyager - Elite Force 2|quake3|port_query=29253
-squad|Squad|valve|port=7787,port_query=27165
+squad|Squad|squad|port=7787,port_query=27165
 swbf|Star Wars: Battlefront|gamespy2|port_query=3658
 swbf2|Star Wars: Battlefront 2|gamespy2|port_query=3658
 swjk|Star Wars Jedi Knight: Jedi Academy (2003)|quake3|port_query=29070

--- a/protocols/squad.js
+++ b/protocols/squad.js
@@ -1,0 +1,16 @@
+const Valve = require('./valve');
+
+class Squad extends Valve {
+    constructor() {
+        super();
+    }
+
+    async cleanup(state) {
+        await super.cleanup(state);
+        if (state.raw.rules != null && state.raw.rules.Password_b === "true") {
+            state.password = true;
+        }
+    }
+}
+
+module.exports = Squad;


### PR DESCRIPTION
It seems that squad utilize `Password_b` for passwording servers so the `password` field was incorrect.
This adds a fix after cleanup has been run in a similar fashion to the Battalion 1944 fix.